### PR TITLE
"removelinks" error

### DIFF
--- a/gframe/premake4.lua
+++ b/gframe/premake4.lua
@@ -32,7 +32,6 @@ project "ygopro"
         excludes { "COSOperator.*" }
         links { "event_pthreads", "GL", "dl", "pthread" }
     configuration "linux"
-        removelinks { "lua" }
         links { "lua5.2" }
         if USE_IRRKLANG then
             defines { "YGOPRO_USE_IRRKLANG" }


### PR DESCRIPTION
when i build in ubuntu 17.10
i got this message:

...-gui-builder/ygopro_sound/ygopro/gframe/premake4.lua:35: attempt to call global 'removelinks' (a nil value)