### PR TITLE
fix spell/trap displaying

### DIFF
--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1160,7 +1160,7 @@ void Game::DrawDeckBd() {
 			myswprintf(textBuffer, L"%ls", dataManager.GetName(ptr->first));
 			DrawShadowText(textFont, textBuffer, Resize(860, 165 + i * 66, 955, 185 + i * 66), Resize(1, 1, 0, 0));
 			const wchar_t* ptype = dataManager.FormatType(ptr->second.type);
-			DrawShadowText(textFont, textBuffer, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
+			DrawShadowText(textFont, ptype, Resize(860, 187 + i * 66, 955, 207 + i * 66), Resize(1, 1, 0, 0));
 			textBuffer[0] = 0;
 			if((ptr->second.ot & 0x3) == 1)
 				wcscat(textBuffer, L"[OCG]");


### PR DESCRIPTION
it displays the card name at the 2nd row. it should display [Spell] or [Trap] instead.
![bug](https://user-images.githubusercontent.com/19840160/37823430-67fb7b9e-2ec4-11e8-84b9-ad73eb55d8db.png)
