### PR TITLE
The solution to Mac build fail

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -21,7 +21,7 @@ solution "ygo"
         libdirs { "/usr/local/lib" }
 
     configuration "macosx"
-        defines { "LUA_USE_MACOSX" }
+        defines { "LUA_USE_MACOSX", "DBL_MAX_10_EXP=+308", "DBL_MANT_DIG=53" }
         includedirs { "/usr/local/include", "/usr/local/include/*" }
         libdirs { "/usr/local/lib", "/usr/X11/lib" }
         buildoptions { "-stdlib=libc++" }


### PR DESCRIPTION
a reference for MCPro Travis. This may be useless in this repo because it's not building Mac.