### PR TITLE
clean dep finding path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,8 +635,8 @@ jobs:
     - name: Install dependencies
       if: matrix.static-link != true
       run: |
-        brew install opus opusfile libvorbis zlib
-#        brew install sqlite libx11 freetype libevent libjpeg-turbo libpng xz
+        brew install libevent opus opusfile libvorbis zlib 
+#        brew install sqlite libx11 freetype libjpeg-turbo libpng xz
 
     - name: Install NASM
       if: matrix.static-link == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -627,7 +627,7 @@ jobs:
     - name: Install dependencies
       if: matrix.static-link != true
       run: |
-        brew install libevent opus opusfile libvorbis zlib 
+        brew install libevent opus opusfile libvorbis zlib
 #        brew install sqlite libx11 freetype libjpeg-turbo libpng xz
 
     - name: Install NASM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -565,15 +565,7 @@ jobs:
     - name: Use premake to generate make files (static link)
       if: matrix.static-link == true
       run: |
-        ./premake5 gmake \
-          --build-event \
-          --build-jpeg \
-          --build-png \
-          --build-zlib \
-          --build-freetype \
-          --build-sqlite \
-          --build-lzma \
-          --build-opus-vorbis
+        ./premake5 gmake --build-all
 
     - name: Make
       run: |
@@ -710,14 +702,7 @@ jobs:
       if: matrix.static-link == true
       run: |
         ./premake5 gmake ${{ matrix.cross-build-intel == true && '--mac-intel' || '' }} ${{ matrix.cross-build-arm == true && '--mac-arm' || '' }} \
-          --build-event \
-          --build-jpeg \
-          --build-png \
-          --build-zlib \
-          --build-freetype \
-          --build-sqlite \
-          --build-lzma \
-          --build-opus-vorbis
+          --build-all
 
     - name: Make
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
     - name: Extract sqlite
       run: |
         7z x ${{ steps.sqlite.outputs.filepath }}
-        mv sqlite-amalgamation-3510300 sqlite3
+        mv sqlite-amalgamation-3510300 sqlite
 
     - name: Download lzma (xz)
       id: lzma
@@ -257,7 +257,7 @@ jobs:
           !jpeg/testimages/
           png/
           zlib/
-          sqlite3/
+          sqlite/
           lzma/
           miniaudio/
           !miniaudio/external/opus/dnn/

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@
 /lua
 /miniaudio
 /png
-/sqlite3
+/sqlite
 /lzma
 /zlib
 /gframe/*.ico

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -11,18 +11,17 @@ project "YGOPro"
     includedirs { "../ocgcore" }
     links { "ocgcore" }
 
-    local dependencies = { "lua", "event", "irrlicht", "jpeg", "png", "zlib", "freetype", "sqlite", "lzma" }
 
     if BUILD_FREETYPE then
         includedirs { FREETYPE_CUSTOM_INCLUDE_DIR }
     end
 
-    for _, dep in ipairs(dependencies) do
-        local upper = string.upper(dep)
+    for _, dep in ipairs(DEPENDENCIES_METADATA) do
+        local upper = string.upper(dep.name)
         includedirs { _G[upper .. "_INCLUDE_DIR"] }
         if _G["BUILD_" .. upper] then
             -- When building from source, the dependencies will be linked with their project names, which can't be changed via options.
-            links { dep }
+            links { dep.name }
         else
             links { _G[upper .. "_LIB_NAME"] }
             libdirs { _G[upper .. "_LIB_DIR"] }

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -8,7 +8,9 @@ project "YGOPro"
     defines { "_IRR_STATIC_LIB_" }
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore", EVENT_INCLUDE_DIR, IRRLICHT_INCLUDE_DIR, JPEG_INCLUDE_DIR, ZLIB_INCLUDE_DIR, LZMA_INCLUDE_DIR, SQLITE_INCLUDE_DIR }
-    links { "ocgcore", "lzma", "sqlite3", "irrlicht", "png", "freetype", "event" }
+    links { "ocgcore" }
+
+    -- When building from source, the dependencies will be linked with their project names, which can't be changed via options.
 
     if BUILD_LUA then
         links { "lua" }
@@ -17,12 +19,17 @@ project "YGOPro"
         libdirs { LUA_LIB_DIR }
     end
 
-    if not BUILD_EVENT then
+    if BUILD_EVENT then
+        links { "event" }
+    else
+        links { EVENT_LIB_NAME, EVENT_PTHREADS_LIB_NAME }
         libdirs { EVENT_LIB_DIR }
-        links { "event_pthreads" }
     end
 
-    if not BUILD_IRRLICHT then
+    if BUILD_IRRLICHT then
+        links { "irrlicht" }
+    else
+        links { IRRLICHT_LIB_NAME }
         libdirs { IRRLICHT_LIB_DIR }
     end
 
@@ -33,7 +40,10 @@ project "YGOPro"
         libdirs { JPEG_LIB_DIR }
     end
 
-    if not BUILD_PNG then
+    if BUILD_PNG then
+        links { "png" }
+    else
+        links { PNG_LIB_NAME }
         libdirs { PNG_LIB_DIR }
     end
 
@@ -46,16 +56,24 @@ project "YGOPro"
 
     if BUILD_FREETYPE then
         includedirs { FREETYPE_CUSTOM_INCLUDE_DIR, FREETYPE_INCLUDE_DIR }
+        links { "freetype" }
     else
         includedirs { FREETYPE_INCLUDE_DIR }
+        links { FREETYPE_LIB_NAME }
         libdirs { FREETYPE_LIB_DIR }
     end
 
-    if not BUILD_SQLITE then
+    if BUILD_SQLITE then
+        links { "sqlite3" }
+    else
+        links { SQLITE_LIB_NAME }
         libdirs { SQLITE_LIB_DIR }
     end
 
-    if not BUILD_LZMA then
+    if BUILD_LZMA then
+        links { "lzma" }
+    else
+        links { LZMA_LIB_NAME }
         libdirs { LZMA_LIB_DIR }
     end
 
@@ -73,7 +91,7 @@ project "YGOPro"
                 defines { "YGOPRO_MINIAUDIO_SUPPORT_OPUS_VORBIS" }
                 includedirs { MINIAUDIO_OPUS_INCLUDE_DIR, MINIAUDIO_VORBIS_INCLUDE_DIR }
                 if not MINIAUDIO_BUILD_OPUS_VORBIS then
-                    links { "opusfile", "vorbisfile", "opus", "vorbis", "ogg" }
+                    links { OPUS_LIB_NAME, OPUSFILE_LIB_NAME, VORBIS_LIB_NAME, VORBISFILE_LIB_NAME, OGG_LIB_NAME }
                     libdirs { OPUS_LIB_DIR, OPUSFILE_LIB_DIR, VORBIS_LIB_DIR, OGG_LIB_DIR }
                 end
             end

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -7,74 +7,30 @@ project "YGOPro"
 
     defines { "_IRR_STATIC_LIB_" }
     files { "*.cpp", "*.h" }
-    includedirs { "../ocgcore", EVENT_INCLUDE_DIR, IRRLICHT_INCLUDE_DIR, JPEG_INCLUDE_DIR, ZLIB_INCLUDE_DIR, LZMA_INCLUDE_DIR, SQLITE_INCLUDE_DIR }
+
+    includedirs { "../ocgcore" }
     links { "ocgcore" }
 
-    -- When building from source, the dependencies will be linked with their project names, which can't be changed via options.
-
-    if BUILD_LUA then
-        links { "lua" }
-    else
-        links { LUA_LIB_NAME }
-        libdirs { LUA_LIB_DIR }
-    end
-
-    if BUILD_EVENT then
-        links { "event" }
-    else
-        links { EVENT_LIB_NAME, EVENT_PTHREADS_LIB_NAME }
-        libdirs { EVENT_LIB_DIR }
-    end
-
-    if BUILD_IRRLICHT then
-        links { "irrlicht" }
-    else
-        links { IRRLICHT_LIB_NAME }
-        libdirs { IRRLICHT_LIB_DIR }
-    end
-
-    if BUILD_JPEG then
-        links { "jpeg" }
-    else
-        links { JPEG_LIB_NAME }
-        libdirs { JPEG_LIB_DIR }
-    end
-
-    if BUILD_PNG then
-        links { "png" }
-    else
-        links { PNG_LIB_NAME }
-        libdirs { PNG_LIB_DIR }
-    end
-
-    if BUILD_ZLIB then
-        links { "zlib" }
-    else
-        links { ZLIB_LIB_NAME }
-        libdirs { ZLIB_LIB_DIR }
-    end
+    local dependencies = { "lua", "event", "irrlicht", "jpeg", "png", "zlib", "freetype", "sqlite", "lzma" }
 
     if BUILD_FREETYPE then
-        includedirs { FREETYPE_CUSTOM_INCLUDE_DIR, FREETYPE_INCLUDE_DIR }
-        links { "freetype" }
-    else
-        includedirs { FREETYPE_INCLUDE_DIR }
-        links { FREETYPE_LIB_NAME }
-        libdirs { FREETYPE_LIB_DIR }
+        includedirs { FREETYPE_CUSTOM_INCLUDE_DIR }
     end
 
-    if BUILD_SQLITE then
-        links { "sqlite" }
-    else
-        links { SQLITE_LIB_NAME }
-        libdirs { SQLITE_LIB_DIR }
+    for _, dep in ipairs(dependencies) do
+        local upper = string.upper(dep)
+        includedirs { _G[upper .. "_INCLUDE_DIR"] }
+        if _G["BUILD_" .. upper] then
+            -- When building from source, the dependencies will be linked with their project names, which can't be changed via options.
+            links { dep }
+        else
+            links { _G[upper .. "_LIB_NAME"] }
+            libdirs { _G[upper .. "_LIB_DIR"] }
+        end
     end
 
-    if BUILD_LZMA then
-        links { "lzma" }
-    else
-        links { LZMA_LIB_NAME }
-        libdirs { LZMA_LIB_DIR }
+    if not BUILD_EVENT then
+        links { EVENT_PTHREADS_LIB_NAME }
     end
 
     if USE_SIMD == "none" then

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -64,7 +64,7 @@ project "YGOPro"
     end
 
     if BUILD_SQLITE then
-        links { "sqlite3" }
+        links { "sqlite" }
     else
         links { SQLITE_LIB_NAME }
         libdirs { SQLITE_LIB_DIR }

--- a/premake/sqlite/premake5.lua
+++ b/premake/sqlite/premake5.lua
@@ -1,4 +1,4 @@
-project "sqlite3"
+project "sqlite"
     kind "StaticLib"
 
     files { "sqlite3.c", "sqlite3.h" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,10 +1,10 @@
 ----- YGOPro build configuration script using Premake5
 
---- Supported systems: Windows, Linux, MacOS
+--- Supported systems: Windows, Linux, macOS
 
--- Windows (Visual Studio) build supports x86, x86_64, and ARM64.
+-- Windows (Visual Studio) build supports x86, x86_64, and ARM64, with cross-compilation support.
 -- Linux build supports x86_64 and ARM64.
--- MacOS build supports x86_64 and ARM64, and it supports cross-compilation.
+-- macOS build supports x86_64 and ARM64, with cross-compilation support.
 
 ---- Global settings
 
@@ -16,7 +16,7 @@ USE_AUDIO = true
 AUDIO_LIB = "miniaudio" -- only miniaudio is supported for now
 
 -- Available: none, sse2, avx2, neon, best
--- "best" means avx2 on x86 and neon on ARM
+-- "best" means avx2 on x86-* and neon on ARM
 USE_SIMD = "best"
 
 -- os.hostarch() actually returns the architecture of Premake5, and the official Windows build of Premake5 is 32-bit,
@@ -45,9 +45,9 @@ BUILD_LUA = true
 -- (clipboard and IME). Also, Irrlicht's bundled jpeglib/libpng/zlib/lzma are not used here.
 BUILD_IRRLICHT = true
 
--- miniaudio is always built from source (was a header-only library; now an independent subproject).
+-- miniaudio is always built from source (originally a header-only library, now an independent subproject).
 -- When building Opus/Vorbis from source, they are integrated directly into the miniaudio subproject.
--- In order to simplify the build process, support for Ogg format audio (Opus/Vorbis) is optional.
+-- To simplify the build process, support for Ogg format audio (Opus/Vorbis) is optional.
 MINIAUDIO_SUPPORT_OPUS_VORBIS = true
 MINIAUDIO_INCLUDE_DIR = path.getabsolute("./miniaudio")
 MINIAUDIO_OPUS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libopus")
@@ -68,7 +68,7 @@ VORBISFILE_LIB_NAME = "vorbisfile"
 SQLITE_LIB_NAME = "sqlite3"
 ZLIB_LIB_NAME = "z"
 
---- Dependency metadata will be expanded into global variables like LUA_INCLUDE_DIR, LUA_LIB_NAME, LUA_LIB_DIR, etc. when processed.
+--- Dependency metadata entries are used to generate global variables such as LUA_INCLUDE_DIR, LUA_LIB_NAME, LUA_LIB_DIR, etc. during processing.
 
 -- Fields: name, header (for finding directory), header_subdir (for FindHeaderWithSubDir), local_include_dir (for building from source)
 DEPENDENCIES_METADATA = {
@@ -94,11 +94,6 @@ DEPENDENCIES_METADATA = {
         local_include_dir = "./sqlite",
     },
     {
-        name = "lzma",
-        header = "lzma.h",
-        local_include_dir = "./lzma/src/liblzma/api",
-    },
-    {
         name = "irrlicht",
         header = "irrlicht.h",
         local_include_dir = "./irrlicht/include",
@@ -114,13 +109,18 @@ DEPENDENCIES_METADATA = {
         local_include_dir = "./png",
     },
     {
+        name = "lzma",
+        header = "lzma.h",
+        local_include_dir = "./lzma/src/liblzma/api",
+    },
+    {
         name = "zlib",
         header = "zlib.h",
         local_include_dir = "./zlib",
     },
 }
 
--- Those dependencies don't have separate [no-]build-* options, instead them use [no-]build-opus-vorbis as general build options
+-- These dependencies do not have separate [no-]build-* options; instead, they use [no-]build-opus-vorbis as general build option.
 MINIAUDIO_DEPENDENCIES_METADATA = {
     {
         name = "opus",
@@ -154,20 +154,20 @@ MINIAUDIO_DEPENDENCIES_METADATA = {
 ---
 --- Windows: Prebuilt support is incomplete (static lib, dynamic lib, debug-specific lib to be refined).
 ---
---- Linux: The script already tries hard to find include and lib paths for prebuilt dependencies.
---- In most cases you should not need to manually specify parameters.
+--- Linux: The script already attempts to automatically locate include and lib paths for prebuilt dependencies.
+--- In most cases, you should not need to manually specify parameters.
 --- If a package is not found, manually specify it. If you installed from a well-known package manager,
 --- please consider reporting the issue.
 ---
---- macOS: When using Homebrew, use `DYLD_LIBRARY_PATH=$(brew --prefix)/lib` to ensure finding Homebrew installation paths.
---- Note: macOS/Xcode already provides "system" versions of sqlite and zlib, Homebrew treat those packages as "keg-only",
---- won't install them to the common directories. You must manually specify paths to use Homebrew-installed versions.
+--- macOS: When using Homebrew, use `DYLD_LIBRARY_PATH=$(brew --prefix)/lib` to ensure Homebrew installation paths are found.
+--- Note: macOS/Xcode already provides "system" versions of sqlite and zlib; Homebrew treats those packages as "keg-only"
+--- and won't install them to common directories. You must manually specify paths to use Homebrew-installed versions.
 
 --- Parameters are read from premake options (priority) and environment variables.
 --- Environment variable names are uppercase versions with hyphens replaced by underscores.
 ---
---- Note on default values: Default values should be defined at the top of the script, not as premake option defaults,
---- otherwise the premake default will always have higher priority than environment variables.
+--- Note on default values: Default values should be defined at the top of the script, not as premake option defaults;
+--- otherwise, the premake option default will always take priority over environment variables.
 
 for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name = dep.name
@@ -215,8 +215,8 @@ newoption { trigger = "use-simd", category = "YGOPro", description = "Specify SI
 
 ---- Process options
 
--- Read settings from command line or environment variables
--- If any values are set in the premake options, GetParam will not read them from environment variables.
+-- Read settings from command line or environment variables.
+-- Command-line options take priority over environment variables.
 function GetParam(param)
     return _OPTIONS[param] or os.getenv(string.upper(string.gsub(param,"-","_")))
 end
@@ -254,7 +254,7 @@ function GetPreBuiltDependencyDirectory(dep)
     EnsureAbsoluteDirectory(lib_dir_var)
 end
 
--- Get dependency directories from command line or environment variables, and check their validity.
+-- Set the include directory for a dependency being built from source, and validate its path.
 function GetBuildFromSourceDependencyDirectory(dep)
     local upper = string.upper(dep.name)
     local include_dir_var = upper .. "_INCLUDE_DIR"
@@ -290,7 +290,7 @@ if GetParam("no-dxsdk") then
 end
 if USE_DXSDK and os.istarget("windows") then
     if not os.getenv("DXSDK_DIR") then
-        print("Warning: DXSDK_DIR environment variable not set, it seems you don't have the DirectX SDK installed. DirectX mode will be disabled.")
+        print("::warning:: DXSDK_DIR environment variable not set, it seems you don't have the DirectX SDK installed. DirectX mode will be disabled.")
         USE_DXSDK = false
     end
 end
@@ -330,22 +330,10 @@ end
 
 USE_SIMD = GetParam("use-simd") or USE_SIMD
 
--- Variable indicating whether we are building for Apple Silicon (for cross-compilation on macOS), will be detected automatically if not specified.
+-- Variables indicating the target Mac architecture for cross-compilation; automatically detected based on Premake's
+-- host architecture if neither --mac-arm nor --mac-intel is specified.
 local mac_arm = false
 local mac_intel = false
-
-if not mac_arm and not mac_intel and table.indexof({ "x86", "x86_64", "ARM64" }, PREMAKE_ARCH) == nil then
-    print("Warning: Detected architecture " .. PREMAKE_ARCH .. " seems not supported, trying to build anyway, SIMD will be disabled.")
-    USE_SIMD = "none"
-end
-
-if USE_SIMD == "avx2" or USE_SIMD == "neon" then
-    USE_SIMD = "best"
-end
-
-if os.istarget("windows") and GetParam("vs2026-win7-support") then
-    WIN7_SUPPORT = true
-end
 
 if os.istarget("macosx") then
     if GetParam("mac-arm") then
@@ -356,10 +344,25 @@ if os.istarget("macosx") then
     end
 end
 
+if not mac_arm and not mac_intel and table.indexof({ "x86", "x86_64", "ARM64" }, PREMAKE_ARCH) == nil then
+    print("::warning:: Detected architecture '" .. PREMAKE_ARCH .. "' is not recognized. Proceeding with the build; SIMD will be disabled.")
+    USE_SIMD = "none"
+end
+
+-- Normalize "avx2" and "neon" to "best": downstream code only checks "best",
+-- which already maps to AVX2 on x86-* and NEON on ARM.
+if USE_SIMD == "avx2" or USE_SIMD == "neon" then
+    USE_SIMD = "best"
+end
+
+if os.istarget("windows") and GetParam("vs2026-win7-support") then
+    WIN7_SUPPORT = true
+end
+
 if GetParam("use-openmp") then
     USE_OPENMP = true
     if os.istarget("macosx") then
-        print("Warning: OpenMP is not supported on Clang provided by Xcode.")
+        print("::warning:: OpenMP is not supported on Clang provided by Xcode.")
     end
 end
 
@@ -411,7 +414,7 @@ workspace "YGOPro"
     filter "system:macosx"
         systemversion "11"
         if mac_arm and mac_intel then
-            print("Warning: Universal binary is no longer supported, please choose either --mac-arm or --mac-intel, and combine the binaries with lipo manually.")
+            print("::warning:: Universal binary is no longer supported. Please choose either --mac-arm or --mac-intel and combine the binaries with lipo manually.")
             mac_arm = false
             mac_intel = false
         end
@@ -478,7 +481,7 @@ workspace "YGOPro"
 
     filter "action:vs*"
         cdialect "C11"
-        conformancemode "On" 
+        conformancemode "On"
         buildoptions { "/utf-8" }
         defines { "_CRT_SECURE_NO_WARNINGS" }
 
@@ -497,11 +500,12 @@ workspace "YGOPro"
     include "gframe"
     for _, dep in ipairs(DEPENDENCIES_METADATA) do
         if _G["BUILD_" .. string.upper(dep.name)] then
+            -- Build dependency as subproject, using our pre-provided premake script (copy from the premake directory of the project before running premake)
             include(dep.name .. "/.")
         end
     end
     if USE_AUDIO then
-        if AUDIO_LIB=="miniaudio" then
+        if AUDIO_LIB == "miniaudio" then
             include "miniaudio/."
         end
     end

--- a/premake5.lua
+++ b/premake5.lua
@@ -15,10 +15,12 @@ LUA_LIB_NAME = "lua" -- at most times you need to change those if you don't buil
                      -- most Lua distributions provide a C lib named "lua", but ocgcore requires lua built as C++.
 
 BUILD_EVENT = os.istarget("windows")
+EVENT_PTHREADS_LIB_NAME = "event_pthreads" -- need to link both event_pthreads and event when not building from source
 
 BUILD_FREETYPE = os.istarget("windows")
 
 BUILD_SQLITE = os.istarget("windows")
+SQLITE_LIB_NAME = "sqlite3" -- the lib name should always be "sqlite3" instead of "sqlite"
 
 BUILD_IRRLICHT = true -- modified Irrlicht is required, can't use the official one
 USE_DXSDK = true
@@ -36,6 +38,7 @@ AUDIO_LIB = "miniaudio" -- only miniaudio is supported for now
 -- BUILD_MINIAUDIO is always true
 MINIAUDIO_SUPPORT_OPUS_VORBIS = true
 MINIAUDIO_BUILD_OPUS_VORBIS = os.istarget("windows")
+VORBISFILE_LIB_NAME = "vorbisfile" -- need to link both vorbisfile and vorbis when not building from source
 
 BUILD_LZMA = os.istarget("windows")
 
@@ -52,58 +55,58 @@ local MAC_INTEL = false
 PREMAKE_ARCH = os.hostarch()
 
 -- Default include dirs, those values are ONLY used in static builds, WILL BE IGNORED if set corresponding BUILD_* to false
+MINIAUDIO_INCLUDE_DIR = path.getabsolute("./miniaudio")
+MINIAUDIO_OPUS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libopus")
+MINIAUDIO_VORBIS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libvorbis")
+FREETYPE_CUSTOM_INCLUDE_DIR = path.getabsolute("./freetype/custom")
+
 LUA_INCLUDE_DIR = path.getabsolute("./lua/src")
 EVENT_INCLUDE_DIR = path.getabsolute("./event/include")
 IRRLICHT_INCLUDE_DIR = path.getabsolute("./irrlicht/include")
 JPEG_INCLUDE_DIR = path.getabsolute("./jpeg/src")
 PNG_INCLUDE_DIR = path.getabsolute("./png")
 ZLIB_INCLUDE_DIR = path.getabsolute("./zlib")
-FREETYPE_CUSTOM_INCLUDE_DIR = path.getabsolute("./freetype/custom")
 FREETYPE_INCLUDE_DIR = path.getabsolute("./freetype/include")
 SQLITE_INCLUDE_DIR = path.getabsolute("./sqlite3")
-MINIAUDIO_INCLUDE_DIR = path.getabsolute("./miniaudio")
-MINIAUDIO_OPUS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libopus")
-MINIAUDIO_VORBIS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libvorbis")
 LZMA_INCLUDE_DIR = path.getabsolute("./lzma/src/liblzma/api")
 
--- Fields: name, header, header_subdir (for FindHeaderWithSubDir), findlib (override lib name), libname_var (global holding the lib name)
-local buildDeps = {
-    { name = "lua",      header = "lua.h",                libname_var = "LUA_LIB_NAME"  },
-    { name = "event",    header = "event2/event.h"                                      },
-    { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2"   },
-    { name = "sqlite",   header = "sqlite3.h",            findlib = "sqlite3"           },
-    { name = "lzma",     header = "lzma.h"                                              },
-    { name = "irrlicht", header = "irrlicht.h"                                          },
-    { name = "jpeg",     header = "jpeglib.h",            libname_var = "JPEG_LIB_NAME" },
-    { name = "png",      header = "png.h"                                               },
-    { name = "zlib",     header = "zlib.h",               libname_var = "ZLIB_LIB_NAME" },
-}
 -- Fields: name, header, header_subdir (for FindHeaderWithSubDir)
+local buildDeps = {
+    { name = "lua",      header = "lua.h",                                            },
+    { name = "event",    header = "event2/event.h"                                    },
+    { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2" },
+    { name = "sqlite",   header = "sqlite3.h",                                        },
+    { name = "lzma",     header = "lzma.h"                                            },
+    { name = "irrlicht", header = "irrlicht.h"                                        },
+    { name = "jpeg",     header = "jpeglib.h",                                        },
+    { name = "png",      header = "png.h"                                             },
+    { name = "zlib",     header = "zlib.h",                                           },
+}
+-- miniaudioDeps don't have separate [no-]build-* options, instead them use [no-]build-opus-vorbis as general build options
 local miniaudioDeps = {
-    { name = "opus",     header = "opus/opus.h",          header_subdir = "opus"        },
-    { name = "opusfile", header = "opus/opusfile.h",      header_subdir = "opus"        },
-    { name = "vorbis",   header = "vorbis/vorbisfile.h"                                 },
-    { name = "ogg",      header = "ogg/ogg.h"                                           },
+    { name = "opus",     header = "opus/opus.h",          header_subdir = "opus"      },
+    { name = "opusfile", header = "opus/opusfile.h",      header_subdir = "opus"      },
+    { name = "vorbis",   header = "vorbis/vorbisfile.h"                               },
+    { name = "ogg",      header = "ogg/ogg.h"                                         },
 }
 
--- Read settings from command line or environment variables
--- Default values should be defined at the top of the script.
--- If any values are set in the premake options, GetParam will not read them from environment variables.
+-- Default values should be defined at the top of the script instead of the premake options.
 
 for _, dep in ipairs(buildDeps) do
     local name = dep.name
     local cat  = "YGOPro - " .. name
-    newoption { trigger = "build-"    .. name,       category = cat, description = "" }
-    newoption { trigger = "no-build-" .. name,       category = cat, description = "" }
-    newoption { trigger = name .. "-include-dir",    category = cat, description = "", value = "PATH" }
-    newoption { trigger = name .. "-lib-dir",        category = cat, description = "", value = "PATH" }
-    if dep.libname_var then
-        newoption { trigger = name .. "-lib-name",   category = cat, description = "", value = "NAME" }
-    end
+    newoption { trigger = "build-"    .. name,    category = cat, description = "" }
+    newoption { trigger = "no-build-" .. name,    category = cat, description = "" }
+    newoption { trigger = name .. "-include-dir", category = cat, description = "", value = "PATH" }
+    newoption { trigger = name .. "-lib-dir",     category = cat, description = "", value = "PATH" }
+    newoption { trigger = name .. "-lib-name",    category = cat, description = "", value = "NAME" }
 end
 for _, dep in ipairs(miniaudioDeps) do
-    newoption { trigger = dep.name .. "-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-    newoption { trigger = dep.name .. "-lib-dir",     category = "YGOPro - miniaudio", description = "", value = "PATH" }
+    local name = dep.name
+    local cat  = "YGOPro - miniaudio"
+    newoption { trigger = name .. "-include-dir", category = cat, description = "", value = "PATH" }
+    newoption { trigger = name .. "-lib-dir",     category = cat, description = "", value = "PATH" }
+    newoption { trigger = name .. "-lib-name",    category = cat, description = "", value = "NAME" }
 end
 
 newoption { trigger = "no-dxsdk", category = "YGOPro - irrlicht", description = "" }
@@ -124,6 +127,9 @@ newoption { trigger = "mac-intel", category = "YGOPro", description = "Cross Com
 newoption { trigger = "use-openmp", category = "YGOPro", description = "Enable OpenMP support (edge case)" }
 
 newoption { trigger = "use-simd", category = "YGOPro", description = "", value = "none, sse2, avx2, neon, best" }
+
+-- Read settings from command line or environment variables
+-- If any values are set in the premake options, GetParam will not read them from environment variables.
 
 function GetParam(param)
     return _OPTIONS[param] or os.getenv(string.upper(string.gsub(param,"-","_")))
@@ -148,11 +154,12 @@ end
 
 function GetDependencyDirectory(dep)
     local upper = string.upper(dep.name)
-    local findlib_name = dep.findlib or (dep.libname_var and _G[dep.libname_var]) or dep.name
     local include_dir_var = upper .. "_INCLUDE_DIR"
+    local lib_name_var = upper .. "_LIB_NAME"
     local lib_dir_var = upper .. "_LIB_DIR"
     _G[include_dir_var] = GetParam(dep.name .. "-include-dir") or FindHeaderWithSubDir(dep.header, dep.header_subdir)
-    _G[lib_dir_var] = GetParam(dep.name .. "-lib-dir") or os.findlib(findlib_name)
+    _G[lib_name_var] = GetParam(dep.name .. "-lib-name") or _G[lib_name_var] or dep.name
+    _G[lib_dir_var] = GetParam(dep.name .. "-lib-dir") or os.findlib(_G[lib_name_var])
     CheckDirectory(include_dir_var)
     CheckDirectory(lib_dir_var)
 end
@@ -168,9 +175,6 @@ for _, dep in ipairs(buildDeps) do
         _G[flag] = false
     end
     if not _G[flag] then
-        if dep.libname_var then
-            _G[dep.libname_var] = GetParam(name .. "-lib-name") or _G[dep.libname_var]
-        end
         GetDependencyDirectory(dep)
     end
 end

--- a/premake5.lua
+++ b/premake5.lua
@@ -60,34 +60,76 @@ MINIAUDIO_OPUS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libop
 MINIAUDIO_VORBIS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libvorbis")
 FREETYPE_CUSTOM_INCLUDE_DIR = path.getabsolute("./freetype/custom")
 
-LUA_INCLUDE_DIR = path.getabsolute("./lua/src")
-EVENT_INCLUDE_DIR = path.getabsolute("./event/include")
-IRRLICHT_INCLUDE_DIR = path.getabsolute("./irrlicht/include")
-JPEG_INCLUDE_DIR = path.getabsolute("./jpeg/src")
-PNG_INCLUDE_DIR = path.getabsolute("./png")
-ZLIB_INCLUDE_DIR = path.getabsolute("./zlib")
-FREETYPE_INCLUDE_DIR = path.getabsolute("./freetype/include")
-SQLITE_INCLUDE_DIR = path.getabsolute("./sqlite")
-LZMA_INCLUDE_DIR = path.getabsolute("./lzma/src/liblzma/api")
-
--- Fields: name, header, header_subdir (for FindHeaderWithSubDir)
+-- Fields: name, header, header_subdir (for FindHeaderWithSubDir), local_include_dir (for building from source)
 DEPENDENCIES_METADATA = {
-    { name = "lua",      header = "lua.h",                                            },
-    { name = "event",    header = "event2/event.h"                                    },
-    { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2" },
-    { name = "sqlite",   header = "sqlite3.h",                                        },
-    { name = "lzma",     header = "lzma.h"                                            },
-    { name = "irrlicht", header = "irrlicht.h"                                        },
-    { name = "jpeg",     header = "jpeglib.h",                                        },
-    { name = "png",      header = "png.h"                                             },
-    { name = "zlib",     header = "zlib.h",                                           },
+    {
+        name = "lua",
+        header = "lua.h",
+        local_include_dir = "./lua/src",
+    },
+    {
+        name = "event",
+        header = "event2/event.h",
+        local_include_dir = "./event/include",
+    },
+    {
+        name = "freetype",
+        header = "freetype2/ft2build.h",
+        header_subdir = "freetype2",
+        local_include_dir = "./freetype/include",
+    },
+    {
+        name = "sqlite",
+        header = "sqlite3.h",
+        local_include_dir = "./sqlite",
+    },
+    {
+        name = "lzma",
+        header = "lzma.h",
+        local_include_dir = "./lzma/src/liblzma/api",
+    },
+    {
+        name = "irrlicht",
+        header = "irrlicht.h",
+        local_include_dir = "./irrlicht/include",
+    },
+    {
+        name = "jpeg",
+        header = "jpeglib.h",
+        local_include_dir = "./jpeg/src",
+    },
+    {
+        name = "png",
+        header = "png.h",
+        local_include_dir = "./png",
+    },
+    {
+        name = "zlib",
+        header = "zlib.h",
+        local_include_dir = "./zlib",
+    },
 }
+
 -- Those dependencies don't have separate [no-]build-* options, instead them use [no-]build-opus-vorbis as general build options
 MINIAUDIO_DEPENDENCIES_METADATA = {
-    { name = "opus",     header = "opus/opus.h",          header_subdir = "opus"      },
-    { name = "opusfile", header = "opus/opusfile.h",      header_subdir = "opus"      },
-    { name = "vorbis",   header = "vorbis/vorbisfile.h"                               },
-    { name = "ogg",      header = "ogg/ogg.h"                                         },
+    {
+        name = "opus",
+        header = "opus/opus.h",
+        header_subdir = "opus",
+    },
+    {
+        name = "opusfile",
+        header = "opus/opusfile.h",
+        header_subdir = "opus",
+    },
+    {
+        name = "vorbis",
+        header = "vorbis/vorbisfile.h",
+    },
+    {
+        name = "ogg",
+        header = "ogg/ogg.h",
+    },
 }
 
 -- Default values should be defined at the top of the script instead of the premake options.
@@ -156,8 +198,7 @@ function EnsureAbsoluteDirectory(varname)
 end
 
 -- Get dependency directories from command line or environment variables, and check their validity.
--- Only called if the dependency is not built from source.
-function GetDependencyDirectory(dep)
+function GetPreBuiltDependencyDirectory(dep)
     local upper = string.upper(dep.name)
     local include_dir_var = upper .. "_INCLUDE_DIR"
     local lib_name_var = upper .. "_LIB_NAME"
@@ -169,18 +210,30 @@ function GetDependencyDirectory(dep)
     EnsureAbsoluteDirectory(lib_dir_var)
 end
 
+-- Get dependency directories from command line or environment variables, and check their validity.
+function GetBuildFromSourceDependencyDirectory(dep)
+    local upper = string.upper(dep.name)
+    local include_dir_var = upper .. "_INCLUDE_DIR"
+    _G[include_dir_var] = dep.local_include_dir
+    EnsureAbsoluteDirectory(include_dir_var)
+end
+
 -- Process build flags and external directory settings for all library dependencies.
 for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name  = dep.name
     local upper = string.upper(name)
     local flag  = "BUILD_" .. upper
+    local build = _G[flag] or false
     if GetParam("no-build-" .. name) then
-        _G[flag] = false
+        build = false
     elseif GetParam("build-" .. name) then
-        _G[flag] = true
+        build = true
     end
-    if not _G[flag] then
-        GetDependencyDirectory(dep)
+    _G[flag] = build
+    if build then
+        GetBuildFromSourceDependencyDirectory(dep)
+    else
+        GetPreBuiltDependencyDirectory(dep)
     end
 end
 
@@ -214,7 +267,7 @@ if USE_AUDIO then
             end
             if not MINIAUDIO_BUILD_OPUS_VORBIS then
                 for _, dep in ipairs(MINIAUDIO_DEPENDENCIES_METADATA) do
-                    GetDependencyDirectory(dep)
+                    GetPreBuiltDependencyDirectory(dep)
                 end
             end
         end
@@ -384,7 +437,7 @@ workspace "YGOPro"
     include "gframe"
     for _, dep in ipairs(DEPENDENCIES_METADATA) do
         if _G["BUILD_" .. string.upper(dep.name)] then
-            include(dep.name)
+            include(dep.name .. "/.")
         end
     end
     if USE_AUDIO then

--- a/premake5.lua
+++ b/premake5.lua
@@ -23,6 +23,15 @@ USE_SIMD = "best"
 -- so we can only distinguish between AARCH64 and x86, and must use the ARM build of Premake5 on ARM platforms.
 PREMAKE_ARCH = os.hostarch()
 
+-- Return val if it's not nil; otherwise, return default.
+local function ifnil(val, default)
+    if val ~= nil then
+        return val
+    else
+        return default
+    end
+end
+
 ---- Dependency settings
 
 --- When building dependencies from source, the corresponding source code must be placed in the corresponding location
@@ -170,9 +179,10 @@ MINIAUDIO_DEPENDENCIES_METADATA = {
 --- otherwise, the premake option default will always take priority over environment variables.
 
 for _, dep in ipairs(DEPENDENCIES_METADATA) do
-    local name = dep.name
-    local cat  = "YGOPro - " .. name
-    newoption { trigger = "build-"    .. name,    category = cat, description = "" }
+    local name  = dep.name
+    local cat   = "YGOPro - " .. name
+    local build = ifnil(_G["BUILD_" .. string.upper(name)], BUILD_ALL_FROM_SOURCE)
+    newoption { trigger = "build-"    .. name,    category = cat, description = "Build " .. name .. " from source; default: " .. tostring(build) }
     newoption { trigger = "no-build-" .. name,    category = cat, description = "" }
     newoption { trigger = name .. "-include-dir", category = cat, description = "", value = "PATH" }
     newoption { trigger = name .. "-lib-dir",     category = cat, description = "", value = "PATH" }
@@ -194,9 +204,12 @@ newoption { trigger = "no-audio", category = "YGOPro", description = "Disable au
 newoption { trigger = "audio-lib", category = "YGOPro", description = "Specify audio library (only miniaudio is supported for now)", value = "NAME" }
 
 newoption { trigger = "miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "Enable support for OGG format (Opus and Vorbis) in miniaudio" }
-newoption { trigger = "no-miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "Disable support for OGG format in miniaudio" }
-newoption { trigger = "build-opus-vorbis", category = "YGOPro - miniaudio", description = "Build Opus and Vorbis libraries from source" }
-newoption { trigger = "no-build-opus-vorbis", category = "YGOPro - miniaudio", description = "Do not build Opus and Vorbis libraries from source" }
+newoption { trigger = "no-miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
+do
+    local build_opus_vorbis = ifnil(_G["BUILD_OPUS_VORBIS"], BUILD_ALL_FROM_SOURCE)
+    newoption { trigger = "build-opus-vorbis", category = "YGOPro - miniaudio", description = "Build Opus and Vorbis libraries from source; default: " .. tostring(build_opus_vorbis) }
+    newoption { trigger = "no-build-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
+end
 
 newoption { trigger = "vs2026-win7-support", category = "YGOPro", description = "Enable Windows 7 support (toolset v143) for Visual Studio 2026" }
 
@@ -214,15 +227,6 @@ newoption { trigger = "use-simd", category = "YGOPro", description = "Specify SI
 }}
 
 ---- Process options
-
--- Return val if it's not nil; otherwise, return default.
-local function ifnil(val, default)
-    if val ~= nil then
-        return val
-    else
-        return default
-    end
-end
 
 -- Read settings from command line or environment variables.
 -- Command-line options take priority over environment variables.

--- a/premake5.lua
+++ b/premake5.lua
@@ -66,53 +66,47 @@ MINIAUDIO_OPUS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libop
 MINIAUDIO_VORBIS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libvorbis")
 LZMA_INCLUDE_DIR = path.getabsolute("./lzma/src/liblzma/api")
 
+-- Fields: name, header, header_subdir (for FindHeaderWithSubDir), findlib (override lib name), libname_var (global holding the lib name)
+local buildDeps = {
+    { name = "lua",      header = "lua.h",                libname_var = "LUA_LIB_NAME"  },
+    { name = "event",    header = "event2/event.h"                                      },
+    { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2"   },
+    { name = "sqlite",   header = "sqlite3.h",            findlib = "sqlite3"           },
+    { name = "lzma",     header = "lzma.h"                                              },
+    { name = "irrlicht", header = "irrlicht.h"                                          },
+    { name = "jpeg",     header = "jpeglib.h",            libname_var = "JPEG_LIB_NAME" },
+    { name = "png",      header = "png.h"                                               },
+    { name = "zlib",     header = "zlib.h",               libname_var = "ZLIB_LIB_NAME" },
+}
+-- Fields: name, header, header_subdir (for FindHeaderWithSubDir)
+local miniaudioDeps = {
+    { name = "opus",     header = "opus/opus.h",          header_subdir = "opus"        },
+    { name = "opusfile", header = "opus/opusfile.h",      header_subdir = "opus"        },
+    { name = "vorbis",   header = "vorbis/vorbisfile.h"                                 },
+    { name = "ogg",      header = "ogg/ogg.h"                                           },
+}
+
 -- Read settings from command line or environment variables
--- Default values should be defined at the top of the script. If any values are set in the premake options, GetParam will not
--- read them from environment variables.
+-- Default values should be defined at the top of the script.
+-- If any values are set in the premake options, GetParam will not read them from environment variables.
 
-newoption { trigger = "build-lua", category = "YGOPro - lua", description = "" }
-newoption { trigger = "no-build-lua", category = "YGOPro - lua", description = "" }
-newoption { trigger = "lua-include-dir", category = "YGOPro - lua", description = "", value = "PATH" }
-newoption { trigger = "lua-lib-dir", category = "YGOPro - lua", description = "", value = "PATH" }
-newoption { trigger = "lua-lib-name", category = "YGOPro - lua", description = "", value = "NAME" }
+for _, dep in ipairs(buildDeps) do
+    local name = dep.name
+    local cat  = "YGOPro - " .. name
+    newoption { trigger = "build-"    .. name,       category = cat, description = "" }
+    newoption { trigger = "no-build-" .. name,       category = cat, description = "" }
+    newoption { trigger = name .. "-include-dir",    category = cat, description = "", value = "PATH" }
+    newoption { trigger = name .. "-lib-dir",        category = cat, description = "", value = "PATH" }
+    if dep.libname_var then
+        newoption { trigger = name .. "-lib-name",   category = cat, description = "", value = "NAME" }
+    end
+end
+for _, dep in ipairs(miniaudioDeps) do
+    newoption { trigger = dep.name .. "-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
+    newoption { trigger = dep.name .. "-lib-dir",     category = "YGOPro - miniaudio", description = "", value = "PATH" }
+end
 
-newoption { trigger = "build-event", category = "YGOPro - event", description = "" }
-newoption { trigger = "no-build-event", category = "YGOPro - event", description = "" }
-newoption { trigger = "event-include-dir", category = "YGOPro - event", description = "", value = "PATH" }
-newoption { trigger = "event-lib-dir", category = "YGOPro - event", description = "", value = "PATH" }
-
-newoption { trigger = "build-freetype", category = "YGOPro - freetype", description = "" }
-newoption { trigger = "no-build-freetype", category = "YGOPro - freetype", description = "" }
-newoption { trigger = "freetype-include-dir", category = "YGOPro - freetype", description = "", value = "PATH" }
-newoption { trigger = "freetype-lib-dir", category = "YGOPro - freetype", description = "", value = "PATH" }
-
-newoption { trigger = "build-sqlite", category = "YGOPro - sqlite", description = "" }
-newoption { trigger = "no-build-sqlite", category = "YGOPro - sqlite", description = "" }
-newoption { trigger = "sqlite-include-dir", category = "YGOPro - sqlite", description = "", value = "PATH" }
-newoption { trigger = "sqlite-lib-dir", category = "YGOPro - sqlite", description = "", value = "PATH" }
-
-newoption { trigger = "build-irrlicht", category = "YGOPro - irrlicht", description = "" }
-newoption { trigger = "no-build-irrlicht", category = "YGOPro - irrlicht", description = "" }
-newoption { trigger = "irrlicht-include-dir", category = "YGOPro - irrlicht", description = "", value = "PATH" }
-newoption { trigger = "irrlicht-lib-dir", category = "YGOPro - irrlicht", description = "", value = "PATH" }
 newoption { trigger = "no-dxsdk", category = "YGOPro - irrlicht", description = "" }
-
-newoption { trigger = "build-jpeg", category = "YGOPro - jpeg", description = "" }
-newoption { trigger = "no-build-jpeg", category = "YGOPro - jpeg", description = "" }
-newoption { trigger = "jpeg-include-dir", category = "YGOPro - jpeg", description = "", value = "PATH" }
-newoption { trigger = "jpeg-lib-dir", category = "YGOPro - jpeg", description = "", value = "PATH" }
-newoption { trigger = "jpeg-lib-name", category = "YGOPro - jpeg", description = "", value = "NAME" }
-
-newoption { trigger = "build-png", category = "YGOPro - png", description = "" }
-newoption { trigger = "no-build-png", category = "YGOPro - png", description = "" }
-newoption { trigger = "png-include-dir", category = "YGOPro - png", description = "", value = "PATH" }
-newoption { trigger = "png-lib-dir", category = "YGOPro - png", description = "", value = "PATH" }
-
-newoption { trigger = "build-zlib", category = "YGOPro - zlib", description = "" }
-newoption { trigger = "no-build-zlib", category = "YGOPro - zlib", description = "" }
-newoption { trigger = "zlib-include-dir", category = "YGOPro - zlib", description = "", value = "PATH" }
-newoption { trigger = "zlib-lib-dir", category = "YGOPro - zlib", description = "", value = "PATH" }
-newoption { trigger = "zlib-lib-name", category = "YGOPro - zlib", description = "", value = "NAME" }
 
 newoption { trigger = "no-audio", category = "YGOPro", description = "" }
 newoption { trigger = "audio-lib", category = "YGOPro", description = "", value = "" }
@@ -121,19 +115,6 @@ newoption { trigger = "miniaudio-support-opus-vorbis", category = "YGOPro - mini
 newoption { trigger = "no-miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
 newoption { trigger = "build-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
 newoption { trigger = "no-build-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
-newoption { trigger = "opus-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "opus-lib-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "opusfile-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "opusfile-lib-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "vorbis-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "vorbis-lib-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "ogg-include-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-newoption { trigger = "ogg-lib-dir", category = "YGOPro - miniaudio", description = "", value = "PATH" }
-
-newoption { trigger = "build-lzma", category = "YGOPro - lzma", description = "" }
-newoption { trigger = "no-build-lzma", category = "YGOPro - lzma", description = "" }
-newoption { trigger = "lzma-include-dir", category = "YGOPro - lzma", description = "", value = "PATH" }
-newoption { trigger = "lzma-lib-dir", category = "YGOPro - lzma", description = "", value = "PATH" }
 
 newoption { trigger = "vs2026-win7-support", category = "YGOPro", description = "Enable Windows 7 support (toolset v143) for Visual Studio 2026" }
 
@@ -156,19 +137,27 @@ function FindHeaderWithSubDir(header, subdir)
     return result
 end
 
+function CheckDirectory(varname)
+    local dir = _G[varname]
+    if not dir or dir == "" then
+        print("::warning:: " .. varname .. " is not set")
+    elseif not os.isdir(dir) then
+        print("::warning:: " .. varname .. " is not a valid directory: " .. dir)
+    end
+end
+
+function GetDependencyDirectory(dep)
+    local upper = string.upper(dep.name)
+    local findlib_name = dep.findlib or (dep.libname_var and _G[dep.libname_var]) or dep.name
+    local include_dir_var = upper .. "_INCLUDE_DIR"
+    local lib_dir_var = upper .. "_LIB_DIR"
+    _G[include_dir_var] = GetParam(dep.name .. "-include-dir") or FindHeaderWithSubDir(dep.header, dep.header_subdir)
+    _G[lib_dir_var] = GetParam(dep.name .. "-lib-dir") or os.findlib(findlib_name)
+    CheckDirectory(include_dir_var)
+    CheckDirectory(lib_dir_var)
+end
+
 -- Process build flags and external directory settings for all library dependencies.
--- Fields: name, header, header_subdir (for FindHeaderWithSubDir), findlib (override lib name), libname_var (global holding the lib name)
-local buildDeps = {
-    { name = "lua",      header = "lua.h",                libname_var = "LUA_LIB_NAME"  },
-    { name = "event",    header = "event2/event.h"                                      },
-    { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2"   },
-    { name = "sqlite",   header = "sqlite3.h",            findlib = "sqlite3"           },
-    { name = "lzma",     header = "lzma.h"                                              },
-    { name = "irrlicht", header = "irrlicht.h"                                          },
-    { name = "jpeg",     header = "jpeglib.h",            libname_var = "JPEG_LIB_NAME" },
-    { name = "png",      header = "png.h"                                               },
-    { name = "zlib",     header = "zlib.h",               libname_var = "ZLIB_LIB_NAME" },
-}
 for _, dep in ipairs(buildDeps) do
     local name  = dep.name
     local upper = string.upper(name)
@@ -182,21 +171,7 @@ for _, dep in ipairs(buildDeps) do
         if dep.libname_var then
             _G[dep.libname_var] = GetParam(name .. "-lib-name") or _G[dep.libname_var]
         end
-        local findlib_name = dep.findlib or (dep.libname_var and _G[dep.libname_var]) or name
-        local include_dir_var = upper .. "_INCLUDE_DIR"
-        local lib_dir_var = upper .. "_LIB_DIR"
-        _G[include_dir_var] = GetParam(name .. "-include-dir") or FindHeaderWithSubDir(dep.header, dep.header_subdir)
-        _G[lib_dir_var] = GetParam(name .. "-lib-dir") or os.findlib(findlib_name)
-        if not _G[include_dir_var] then
-            print("::warning:: Include directory for " .. name .. " not found, you may need to specify it with --" .. name .. "-include-dir")
-        elseif not os.isdir(_G[include_dir_var]) then
-            print("::warning:: Include directory for " .. name .. " is not a valid directory: " .. _G[include_dir_var])
-        end
-        if not _G[lib_dir_var] then
-            print("::warning:: Library directory for " .. name .. " not found, you may need to specify it with --" .. name .. "-lib-dir")
-        elseif not os.isdir(_G[lib_dir_var]) then
-            print("::warning:: Library directory for " .. name .. " is not a valid directory: " .. _G[lib_dir_var])
-        end
+        GetDependencyDirectory(dep)
     end
 end
 
@@ -236,14 +211,9 @@ if USE_AUDIO then
                 MINIAUDIO_BUILD_OPUS_VORBIS = true
             end
             if not MINIAUDIO_BUILD_OPUS_VORBIS then
-                OPUS_INCLUDE_DIR = GetParam("opus-include-dir") or FindHeaderWithSubDir("opus/opus.h", "opus")
-                OPUS_LIB_DIR = GetParam("opus-lib-dir") or os.findlib("opus")
-                OPUSFILE_INCLUDE_DIR = GetParam("opusfile-include-dir") or FindHeaderWithSubDir("opus/opusfile.h", "opus")
-                OPUSFILE_LIB_DIR = GetParam("opusfile-lib-dir") or os.findlib("opusfile")
-                VORBIS_INCLUDE_DIR = GetParam("vorbis-include-dir") or os.findheader("vorbis/vorbisfile.h")
-                VORBIS_LIB_DIR = GetParam("vorbis-lib-dir") or os.findlib("vorbis")
-                OGG_INCLUDE_DIR = GetParam("ogg-include-dir") or os.findheader("ogg/ogg.h")
-                OGG_LIB_DIR = GetParam("ogg-lib-dir") or os.findlib("ogg")
+                for _, dep in ipairs(miniaudioDeps) do
+                    GetDependencyDirectory(dep)
+                end
             end
         end
     else

--- a/premake5.lua
+++ b/premake5.lua
@@ -215,13 +215,22 @@ newoption { trigger = "use-simd", category = "YGOPro", description = "Specify SI
 
 ---- Process options
 
--- Read settings from command line or environment variables.
--- Command-line options take priority over environment variables.
-function GetParam(param)
-    return _OPTIONS[param] or os.getenv(string.upper(string.gsub(param,"-","_")))
+-- Return val if it's not nil; otherwise, return default.
+local function ifnil(val, default)
+    if val ~= nil then
+        return val
+    else
+        return default
+    end
 end
 
-function FindHeaderWithSubDir(header, subdir)
+-- Read settings from command line or environment variables.
+-- Command-line options take priority over environment variables.
+local function GetParam(param)
+    return ifnil(_OPTIONS[param], os.getenv(string.upper(string.gsub(param,"-","_"))))
+end
+
+local function FindHeaderWithSubDir(header, subdir)
     local result = os.findheader(header)
     if result and subdir then
         result = path.join(result, subdir)
@@ -229,7 +238,7 @@ function FindHeaderWithSubDir(header, subdir)
     return result
 end
 
-function EnsureAbsoluteDirectory(varname)
+local function EnsureAbsoluteDirectory(varname)
     local dir = _G[varname]
     if not dir or dir == "" then
         print("::warning:: " .. varname .. " is not set")
@@ -242,7 +251,7 @@ function EnsureAbsoluteDirectory(varname)
 end
 
 -- Get dependency directories from command line or environment variables, and check their validity.
-function GetPreBuiltDependencyDirectory(dep)
+local function GetPreBuiltDependencyDirectory(dep)
     local upper = string.upper(dep.name)
     local include_dir_var = upper .. "_INCLUDE_DIR"
     local lib_name_var = upper .. "_LIB_NAME"
@@ -255,7 +264,7 @@ function GetPreBuiltDependencyDirectory(dep)
 end
 
 -- Set the include directory for a dependency being built from source, and validate its path.
-function GetBuildFromSourceDependencyDirectory(dep)
+local function GetBuildFromSourceDependencyDirectory(dep)
     local upper = string.upper(dep.name)
     local include_dir_var = upper .. "_INCLUDE_DIR"
     _G[include_dir_var] = dep.local_include_dir
@@ -271,7 +280,7 @@ for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name  = dep.name
     local upper = string.upper(name)
     local flag  = "BUILD_" .. upper
-    local build = _G[flag] or BUILD_ALL_FROM_SOURCE
+    local build = ifnil(_G[flag], BUILD_ALL_FROM_SOURCE)
     if GetParam("no-build-" .. name) then
         build = false
     elseif GetParam("build-" .. name) then

--- a/premake5.lua
+++ b/premake5.lua
@@ -152,6 +152,8 @@ function CheckDirectory(varname)
     end
 end
 
+-- Get dependency directories from command line or environment variables, and check their validity.
+-- Only called if the dependency is not built from source.
 function GetDependencyDirectory(dep)
     local upper = string.upper(dep.name)
     local include_dir_var = upper .. "_INCLUDE_DIR"
@@ -169,10 +171,10 @@ for _, dep in ipairs(buildDeps) do
     local name  = dep.name
     local upper = string.upper(name)
     local flag  = "BUILD_" .. upper
-    if GetParam("build-" .. name) then
-        _G[flag] = true
-    elseif GetParam("no-build-" .. name) then
+    if GetParam("no-build-" .. name) then
         _G[flag] = false
+    elseif GetParam("build-" .. name) then
+        _G[flag] = true
     end
     if not _G[flag] then
         GetDependencyDirectory(dep)
@@ -191,22 +193,15 @@ end
 
 if GetParam("no-audio") then
     USE_AUDIO = false
-elseif GetParam("no-use-miniaudio") then
-    print("Warning: --no-use-miniaudio is deprecated, use --no-audio")
-    USE_AUDIO = false
-elseif GetParam("use-miniaudio") then
-    print("Warning: --use-miniaudio is deprecated, use --audio-lib=miniaudio")
-    USE_AUDIO = true
-    AUDIO_LIB = "miniaudio"
 end
 
 if USE_AUDIO then
     AUDIO_LIB = GetParam("audio-lib") or AUDIO_LIB
     if AUDIO_LIB == "miniaudio" then
-        if GetParam("miniaudio-support-opus-vorbis") then
-            MINIAUDIO_SUPPORT_OPUS_VORBIS = true
-        elseif GetParam("no-miniaudio-support-opus-vorbis") then
+        if GetParam("no-miniaudio-support-opus-vorbis") then
             MINIAUDIO_SUPPORT_OPUS_VORBIS = false
+        elseif GetParam("miniaudio-support-opus-vorbis") then
+            MINIAUDIO_SUPPORT_OPUS_VORBIS = true
         end
         if MINIAUDIO_SUPPORT_OPUS_VORBIS then
             if GetParam("no-build-opus-vorbis") then

--- a/premake5.lua
+++ b/premake5.lua
@@ -11,7 +11,8 @@
 --          but build them on Windows, due to the lack of package manager on Windows.
 
 BUILD_LUA = true
-LUA_LIB_NAME = "lua" -- change this if you don't build Lua
+LUA_LIB_NAME = "lua" -- at most times you need to change those if you don't build Lua from source:
+                     -- most Lua distributions provide a C lib named "lua", but ocgcore requires lua built as C++.
 
 BUILD_EVENT = os.istarget("windows")
 
@@ -155,99 +156,48 @@ function FindHeaderWithSubDir(header, subdir)
     return result
 end
 
-if GetParam("build-lua") then
-    BUILD_LUA = true
-elseif GetParam("no-build-lua") then
-    BUILD_LUA = false
-end
-if not BUILD_LUA then
-    -- at most times you need to change those if you change BUILD_LUA to false
-    -- make sure your lua lib is built with C++ and version >= 5.3
-    LUA_LIB_NAME = GetParam("lua-lib-name") or LUA_LIB_NAME
-    LUA_INCLUDE_DIR = GetParam("lua-include-dir") or os.findheader("lua.h")
-    LUA_LIB_DIR = GetParam("lua-lib-dir") or os.findlib(LUA_LIB_NAME)
-end
-
-if GetParam("build-event") then
-    BUILD_EVENT = true
-elseif GetParam("no-build-event") then
-    BUILD_EVENT = false
-end
-if not BUILD_EVENT then
-    EVENT_INCLUDE_DIR = GetParam("event-include-dir") or os.findheader("event2/event.h")
-    EVENT_LIB_DIR = GetParam("event-lib-dir") or os.findlib("event")
-end
-
-if GetParam("build-freetype") then
-    BUILD_FREETYPE = true
-elseif GetParam("no-build-freetype") then
-    BUILD_FREETYPE = false
-end
-if not BUILD_FREETYPE then
-    FREETYPE_INCLUDE_DIR = GetParam("freetype-include-dir") or FindHeaderWithSubDir("freetype2/ft2build.h", "freetype2")
-    FREETYPE_LIB_DIR = GetParam("freetype-lib-dir") or os.findlib("freetype")
-end
-
-if GetParam("build-sqlite") then
-    BUILD_SQLITE = true
-elseif GetParam("no-build-sqlite") then
-    BUILD_SQLITE = false
-end
-if not BUILD_SQLITE then
-    SQLITE_INCLUDE_DIR = GetParam("sqlite-include-dir") or os.findheader("sqlite3.h")
-    SQLITE_LIB_DIR = GetParam("sqlite-lib-dir") or os.findlib("sqlite3")
-end
-
-if GetParam("build-lzma") then
-    BUILD_LZMA = true
-elseif GetParam("no-build-lzma") then
-    BUILD_LZMA = false
-end
-if not BUILD_LZMA then
-    LZMA_INCLUDE_DIR = GetParam("lzma-include-dir") or os.findheader("lzma.h")
-    LZMA_LIB_DIR = GetParam("lzma-lib-dir") or os.findlib("lzma")
-end
-
-if GetParam("build-irrlicht") then
-    BUILD_IRRLICHT = true
-elseif GetParam("no-build-irrlicht") then
-    BUILD_IRRLICHT = false
-end
-if not BUILD_IRRLICHT then
-    IRRLICHT_INCLUDE_DIR = GetParam("irrlicht-include-dir") or os.findheader("irrlicht.h")
-    IRRLICHT_LIB_DIR = GetParam("irrlicht-lib-dir") or os.findlib("irrlicht")
-end
-
-if GetParam("build-jpeg") then
-    BUILD_JPEG = true
-elseif GetParam("no-build-jpeg") then
-    BUILD_JPEG = false
-end
-if not BUILD_JPEG then
-    JPEG_LIB_NAME = GetParam("jpeg-lib-name") or JPEG_LIB_NAME
-    JPEG_INCLUDE_DIR = GetParam("jpeg-include-dir") or os.findheader("jpeglib.h")
-    JPEG_LIB_DIR = GetParam("jpeg-lib-dir") or os.findlib(JPEG_LIB_NAME)
-end
-
-if GetParam("build-png") then
-    BUILD_PNG = true
-elseif GetParam("no-build-png") then
-    BUILD_PNG = false
-end
-if not BUILD_PNG then
-    PNG_INCLUDE_DIR = GetParam("png-include-dir") or os.findheader("png.h")
-    PNG_LIB_DIR = GetParam("png-lib-dir") or os.findlib("png")
-end
-
-if GetParam("build-zlib") then
-    BUILD_ZLIB = true
-elseif GetParam("no-build-zlib") then
-    BUILD_ZLIB = false
-end
-if not BUILD_ZLIB then
-    ZLIB_LIB_NAME = GetParam("zlib-lib-name") or ZLIB_LIB_NAME
-    ZLIB_INCLUDE_DIR = GetParam("zlib-include-dir") or os.findheader("zlib.h")
-    ZLIB_LIB_DIR = GetParam("zlib-lib-dir") or os.findlib(ZLIB_LIB_NAME)
+-- Process build flags and external directory settings for all library dependencies.
+-- Fields: name, header, header_subdir (for FindHeaderWithSubDir), findlib (override lib name), libname_var (global holding the lib name)
+local buildDeps = {
+    { name = "lua",      header = "lua.h",                libname_var = "LUA_LIB_NAME"  },
+    { name = "event",    header = "event2/event.h"                                      },
+    { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2"   },
+    { name = "sqlite",   header = "sqlite3.h",            findlib = "sqlite3"           },
+    { name = "lzma",     header = "lzma.h"                                              },
+    { name = "irrlicht", header = "irrlicht.h"                                          },
+    { name = "jpeg",     header = "jpeglib.h",            libname_var = "JPEG_LIB_NAME" },
+    { name = "png",      header = "png.h"                                               },
+    { name = "zlib",     header = "zlib.h",               libname_var = "ZLIB_LIB_NAME" },
+}
+for _, dep in ipairs(buildDeps) do
+    local name  = dep.name
+    local upper = string.upper(name)
+    local flag  = "BUILD_" .. upper
+    if GetParam("build-" .. name) then
+        _G[flag] = true
+    elseif GetParam("no-build-" .. name) then
+        _G[flag] = false
+    end
+    if not _G[flag] then
+        if dep.libname_var then
+            _G[dep.libname_var] = GetParam(name .. "-lib-name") or _G[dep.libname_var]
+        end
+        local findlib_name = dep.findlib or (dep.libname_var and _G[dep.libname_var]) or name
+        local include_dir_var = upper .. "_INCLUDE_DIR"
+        local lib_dir_var = upper .. "_LIB_DIR"
+        _G[include_dir_var] = GetParam(name .. "-include-dir") or FindHeaderWithSubDir(dep.header, dep.header_subdir)
+        _G[lib_dir_var] = GetParam(name .. "-lib-dir") or os.findlib(findlib_name)
+        if not _G[include_dir_var] then
+            print("::warning:: Include directory for " .. name .. " not found, you may need to specify it with --" .. name .. "-include-dir")
+        elseif not os.isdir(_G[include_dir_var]) then
+            print("::warning:: Include directory for " .. name .. " is not a valid directory: " .. _G[include_dir_var])
+        end
+        if not _G[lib_dir_var] then
+            print("::warning:: Library directory for " .. name .. " not found, you may need to specify it with --" .. name .. "-lib-dir")
+        elseif not os.isdir(_G[lib_dir_var]) then
+            print("::warning:: Library directory for " .. name .. " is not a valid directory: " .. _G[lib_dir_var])
+        end
+    end
 end
 
 if GetParam("no-dxsdk") then

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,66 +1,76 @@
--- Supported systems: Windows, Linux, MacOS
+----- YGOPro build configuration script using Premake5
+
+--- Supported systems: Windows, Linux, MacOS
 
 -- Windows (Visual Studio) build supports x86, x86_64, and ARM64.
 -- Linux build supports x86_64 and ARM64.
 -- MacOS build supports x86_64 and ARM64, and it supports cross-compilation.
 
--- Global settings
+---- Global settings
 
--- Default: Build Lua, Irrlicht, miniaudio from source on all systems.
---          Don't build event, freetype, sqlite, jpeg, png, zlib, opus, vorbis on Linux or MacOS, use package manager,
---          but build them on Windows, due to the lack of package manager on Windows.
+--- Use global variables to share settings across different scripts.
 
-BUILD_LUA = true
-LUA_LIB_NAME = "lua" -- at most times you need to change those if you don't build Lua from source:
-                     -- most Lua distributions provide a C lib named "lua", but ocgcore requires lua built as C++.
-
-BUILD_EVENT = os.istarget("windows")
-EVENT_PTHREADS_LIB_NAME = "event_pthreads" -- need to link both event_pthreads and event when not building from source
-
-BUILD_FREETYPE = os.istarget("windows")
-
-BUILD_SQLITE = os.istarget("windows")
-SQLITE_LIB_NAME = "sqlite3" -- the lib name should always be "sqlite3" instead of "sqlite"
-
-BUILD_IRRLICHT = true -- modified Irrlicht is required, can't use the official one
 USE_DXSDK = true
-
-BUILD_JPEG = os.istarget("windows") -- libjpeg-turbo is required, can't use the bundled IJG jpeglib from Irrlicht
-JPEG_LIB_NAME = "jpeg" -- use the libjpeg API of libjpeg-turbo, the lib name should always be "jpeg", just in case
-
-BUILD_PNG = os.istarget("windows")
-
-BUILD_ZLIB = os.istarget("windows")
-ZLIB_LIB_NAME = "z" -- the lib name should always be "z", just in case
 
 USE_AUDIO = true
 AUDIO_LIB = "miniaudio" -- only miniaudio is supported for now
--- BUILD_MINIAUDIO is always true
-MINIAUDIO_SUPPORT_OPUS_VORBIS = true
-MINIAUDIO_BUILD_OPUS_VORBIS = os.istarget("windows")
-VORBISFILE_LIB_NAME = "vorbisfile" -- need to link both vorbisfile and vorbis when not building from source
-
-BUILD_LZMA = os.istarget("windows")
 
 -- Available: none, sse2, avx2, neon, best
 -- "best" means avx2 on x86 and neon on ARM
 USE_SIMD = "best"
 
--- Variable indicating whether we are building for Apple Silicon, will be detected automatically if not specified.
-local MAC_ARM = false
-local MAC_INTEL = false
-
 -- os.hostarch() actually returns the architecture of Premake5, and the official Windows build of Premake5 is 32-bit,
 -- so we can only distinguish between AARCH64 and x86, and must use the ARM build of Premake5 on ARM platforms.
 PREMAKE_ARCH = os.hostarch()
 
--- Default include dirs, those values are ONLY used in static builds, WILL BE IGNORED if set corresponding BUILD_* to false
+---- Dependency settings
+
+--- When building dependencies from source, the corresponding source code must be placed in the corresponding location
+--- in the project folder (local), with the folder name fixed as the dependency name and the folder structure fixed as
+--- the official source package extraction.
+---
+--- Some dependencies need extra configuration (run configure scripts, copy or rename files), see the documentation or
+--- the CI workflow script for details.
+
+-- On Windows, build all dependencies from source by default.
+-- On Linux/macOS, most dependencies should be installed via the package manager.
+BUILD_ALL_FROM_SOURCE = os.istarget("windows")
+
+-- Build Lua from source by default:
+-- Most package managers provide Lua compiled as C, but ocgcore requires Lua compiled as C++.
+-- Some package managers do provide lua-c++ variants (e.g. liblua5.4-c++.so), which can be specified manually.
+BUILD_LUA = true
+
+-- Modified Irrlicht is required; the official version from package managers lacks proper CJK support
+-- (clipboard and IME). Also, Irrlicht's bundled jpeglib/libwebp/zlib/lzma are not used here.
+BUILD_IRRLICHT = true
+
+-- miniaudio is always built from source (was a header-only library; now an independent subproject).
+-- When building Opus/Vorbis from source, they are integrated directly into the miniaudio subproject.
+-- In order to simplify the build process, support for Ogg format audio (Opus/Vorbis) is optional.
+MINIAUDIO_SUPPORT_OPUS_VORBIS = true
 MINIAUDIO_INCLUDE_DIR = path.getabsolute("./miniaudio")
 MINIAUDIO_OPUS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libopus")
 MINIAUDIO_VORBIS_INCLUDE_DIR = path.getabsolute("./miniaudio/extras/decoders/libvorbis")
+
+-- When building freetype, a custom include dir is prepended to prioritize custom header files.
 FREETYPE_CUSTOM_INCLUDE_DIR = path.getabsolute("./freetype/custom")
 
--- Fields: name, header, header_subdir (for FindHeaderWithSubDir), local_include_dir (for building from source)
+-- When building libevent from source, event_pthreads is integrated into the event subproject.
+-- When not building from source, both "event" and "event_pthreads" need to be linked.
+EVENT_PTHREADS_LIB_NAME = "event_pthreads"
+
+-- When building Vorbis from source, vorbisfile is integrated into the miniaudio subproject.
+-- When not building from source, both "vorbis" and "vorbisfile" need to be linked.
+VORBISFILE_LIB_NAME = "vorbisfile"
+
+-- The following prebuilt lib names differ from the dependency name:
+SQLITE_LIB_NAME = "sqlite3"
+ZLIB_LIB_NAME = "z"
+
+--- Dependency metadata will be expanded into global variables like LUA_INCLUDE_DIR, LUA_LIB_NAME, LUA_LIB_DIR, etc. when processed.
+
+-- Fields: name, header (for finding directory), header_subdir (for FindHeaderWithSubDir), local_include_dir (for building from source)
 DEPENDENCIES_METADATA = {
     {
         name = "lua",
@@ -132,7 +142,32 @@ MINIAUDIO_DEPENDENCIES_METADATA = {
     },
 }
 
--- Default values should be defined at the top of the script instead of the premake options.
+---- Register options
+
+--- The *-include-dir, *-lib-dir, and *-lib-name options are only used for prebuilt dependencies.
+--- These options are ignored when building from source.
+---
+--- For *-lib-name option: Most users don't need to set it, as the script already provides conventional values.
+--- The only known case where setting it is necessary is when using prebuilt lua-c++, where the lib name must be specified.
+
+--- Platform-specific notes:
+---
+--- Windows: Prebuilt support is incomplete (static lib, dynamic lib, debug-specific lib to be refined).
+---
+--- Linux: The script already tries hard to find include and lib paths for prebuilt dependencies.
+--- In most cases you should not need to manually specify parameters.
+--- If a package is not found, manually specify it. If you installed from a well-known package manager,
+--- please consider reporting the issue.
+---
+--- macOS: When using Homebrew, use `DYLD_LIBRARY_PATH=$(brew --prefix)/lib` to ensure finding Homebrew installation paths.
+--- Note: macOS/Xcode already provides "system" versions of sqlite and zlib, Homebrew treat those packages as "keg-only",
+--- won't install them to the common directories. You must manually specify paths to use Homebrew-installed versions.
+
+--- Parameters are read from premake options (priority) and environment variables.
+--- Environment variable names are uppercase versions with hyphens replaced by underscores.
+---
+--- Note on default values: Default values should be defined at the top of the script, not as premake option defaults,
+--- otherwise the premake default will always have higher priority than environment variables.
 
 for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name = dep.name
@@ -151,28 +186,37 @@ for _, dep in ipairs(MINIAUDIO_DEPENDENCIES_METADATA) do
     newoption { trigger = name .. "-lib-name",    category = cat, description = "", value = "NAME" }
 end
 
-newoption { trigger = "no-dxsdk", category = "YGOPro - irrlicht", description = "" }
+newoption { trigger = "build-all", category = "YGOPro", description = "Build all dependencies from source" }
 
-newoption { trigger = "no-audio", category = "YGOPro", description = "" }
-newoption { trigger = "audio-lib", category = "YGOPro", description = "", value = "" }
+newoption { trigger = "no-dxsdk", category = "YGOPro - irrlicht", description = "Do not use DirectX SDK, disable D3D9 support" }
 
-newoption { trigger = "miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
-newoption { trigger = "no-miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
-newoption { trigger = "build-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
-newoption { trigger = "no-build-opus-vorbis", category = "YGOPro - miniaudio", description = "" }
+newoption { trigger = "no-audio", category = "YGOPro", description = "Disable audio support" }
+newoption { trigger = "audio-lib", category = "YGOPro", description = "Specify audio library (only miniaudio is supported for now)", value = "NAME" }
+
+newoption { trigger = "miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "Enable support for OGG format (Opus and Vorbis) in miniaudio" }
+newoption { trigger = "no-miniaudio-support-opus-vorbis", category = "YGOPro - miniaudio", description = "Disable support for OGG format in miniaudio" }
+newoption { trigger = "build-opus-vorbis", category = "YGOPro - miniaudio", description = "Build Opus and Vorbis libraries from source" }
+newoption { trigger = "no-build-opus-vorbis", category = "YGOPro - miniaudio", description = "Do not build Opus and Vorbis libraries from source" }
 
 newoption { trigger = "vs2026-win7-support", category = "YGOPro", description = "Enable Windows 7 support (toolset v143) for Visual Studio 2026" }
 
 newoption { trigger = "mac-arm", category = "YGOPro", description = "Cross Compile for Apple Silicon Mac" }
 newoption { trigger = "mac-intel", category = "YGOPro", description = "Cross Compile for Intel Mac" }
 
-newoption { trigger = "use-openmp", category = "YGOPro", description = "Enable OpenMP support (edge case)" }
+newoption { trigger = "use-openmp", category = "YGOPro", description = "Enable OpenMP support for card picture resizing (only for benchmarking)" }
 
-newoption { trigger = "use-simd", category = "YGOPro", description = "", value = "none, sse2, avx2, neon, best" }
+newoption { trigger = "use-simd", category = "YGOPro", description = "Specify SIMD instruction set", allowed = {
+    { "none", "Turn off extra SIMD support" },
+    { "sse2", "Use SSE2 instructions" },
+    { "avx2", "Use AVX2 instructions" },
+    { "neon", "Use NEON instructions" },
+    { "best", "Default, use the best SIMD instructions (AVX2 on x86-*, NEON on ARM)" },
+}}
+
+---- Process options
 
 -- Read settings from command line or environment variables
 -- If any values are set in the premake options, GetParam will not read them from environment variables.
-
 function GetParam(param)
     return _OPTIONS[param] or os.getenv(string.upper(string.gsub(param,"-","_")))
 end
@@ -218,12 +262,16 @@ function GetBuildFromSourceDependencyDirectory(dep)
     EnsureAbsoluteDirectory(include_dir_var)
 end
 
+if GetParam("build-all") then
+    BUILD_ALL_FROM_SOURCE = true
+end
+
 -- Process build flags and external directory settings for all library dependencies.
 for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name  = dep.name
     local upper = string.upper(name)
     local flag  = "BUILD_" .. upper
-    local build = _G[flag] or false
+    local build = _G[flag] or BUILD_ALL_FROM_SOURCE
     if GetParam("no-build-" .. name) then
         build = false
     elseif GetParam("build-" .. name) then
@@ -260,12 +308,16 @@ if USE_AUDIO then
             MINIAUDIO_SUPPORT_OPUS_VORBIS = true
         end
         if MINIAUDIO_SUPPORT_OPUS_VORBIS then
+            MINIAUDIO_BUILD_OPUS_VORBIS = BUILD_ALL_FROM_SOURCE
             if GetParam("no-build-opus-vorbis") then
                 MINIAUDIO_BUILD_OPUS_VORBIS = false
             elseif GetParam("build-opus-vorbis") then
                 MINIAUDIO_BUILD_OPUS_VORBIS = true
             end
-            if not MINIAUDIO_BUILD_OPUS_VORBIS then
+            if MINIAUDIO_BUILD_OPUS_VORBIS then
+                -- Opus, Vorbis and Ogg dependencies are integrated into the miniaudio subproject instead of being maintained as separate subprojects.
+                -- Since their locations are predefined in the miniaudio subproject, nothing needs to be done here.
+            else
                 for _, dep in ipairs(MINIAUDIO_DEPENDENCIES_METADATA) do
                     GetPreBuiltDependencyDirectory(dep)
                 end
@@ -278,7 +330,11 @@ end
 
 USE_SIMD = GetParam("use-simd") or USE_SIMD
 
-if not MAC_ARM and not MAC_INTEL and table.indexof({ "x86", "x86_64", "ARM64" }, PREMAKE_ARCH) == nil then
+-- Variable indicating whether we are building for Apple Silicon (for cross-compilation on macOS), will be detected automatically if not specified.
+local mac_arm = false
+local mac_intel = false
+
+if not mac_arm and not mac_intel and table.indexof({ "x86", "x86_64", "ARM64" }, PREMAKE_ARCH) == nil then
     print("Warning: Detected architecture " .. PREMAKE_ARCH .. " seems not supported, trying to build anyway, SIMD will be disabled.")
     USE_SIMD = "none"
 end
@@ -293,10 +349,10 @@ end
 
 if os.istarget("macosx") then
     if GetParam("mac-arm") then
-        MAC_ARM = true
+        mac_arm = true
     end
     if GetParam("mac-intel") then
-        MAC_INTEL = true
+        mac_intel = true
     end
 end
 
@@ -306,6 +362,8 @@ if GetParam("use-openmp") then
         print("Warning: OpenMP is not supported on Clang provided by Xcode.")
     end
 end
+
+---- Premake workspace and project configuration
 
 workspace "YGOPro"
     location "build"
@@ -352,25 +410,27 @@ workspace "YGOPro"
 
     filter "system:macosx"
         systemversion "11"
-        if MAC_ARM and MAC_INTEL then
+        if mac_arm and mac_intel then
             print("Warning: Universal binary is no longer supported, please choose either --mac-arm or --mac-intel, and combine the binaries with lipo manually.")
-            MAC_ARM = false
-            MAC_INTEL = false
+            mac_arm = false
+            mac_intel = false
         end
-        if not MAC_ARM and not MAC_INTEL then
+        if not mac_arm and not mac_intel then
             if PREMAKE_ARCH == "ARM64" then
-                MAC_ARM = true
+                mac_arm = true
             else
-                MAC_INTEL = true
+                mac_intel = true
             end
         end
-        if MAC_ARM then
+        -- We need to specify architecture on macOS to make the premake filters work correctly.
+        if mac_arm then
             architecture "AARCH64"
         end
-        if MAC_INTEL then
+        if mac_intel then
             architecture "x86_64"
         end
 
+    -- We need to specify architecture on Linux to make the premake filters work correctly.
     filter "system:linux"
         if PREMAKE_ARCH == "ARM64" then
             architecture "AARCH64"

--- a/premake5.lua
+++ b/premake5.lua
@@ -42,7 +42,7 @@ BUILD_ALL_FROM_SOURCE = os.istarget("windows")
 BUILD_LUA = true
 
 -- Modified Irrlicht is required; the official version from package managers lacks proper CJK support
--- (clipboard and IME). Also, Irrlicht's bundled jpeglib/libwebp/zlib/lzma are not used here.
+-- (clipboard and IME). Also, Irrlicht's bundled jpeglib/libpng/zlib/lzma are not used here.
 BUILD_IRRLICHT = true
 
 -- miniaudio is always built from source (was a header-only library; now an independent subproject).

--- a/premake5.lua
+++ b/premake5.lua
@@ -71,7 +71,7 @@ SQLITE_INCLUDE_DIR = path.getabsolute("./sqlite")
 LZMA_INCLUDE_DIR = path.getabsolute("./lzma/src/liblzma/api")
 
 -- Fields: name, header, header_subdir (for FindHeaderWithSubDir)
-local buildDeps = {
+DEPENDENCIES_METADATA = {
     { name = "lua",      header = "lua.h",                                            },
     { name = "event",    header = "event2/event.h"                                    },
     { name = "freetype", header = "freetype2/ft2build.h", header_subdir = "freetype2" },
@@ -82,8 +82,8 @@ local buildDeps = {
     { name = "png",      header = "png.h"                                             },
     { name = "zlib",     header = "zlib.h",                                           },
 }
--- miniaudioDeps don't have separate [no-]build-* options, instead them use [no-]build-opus-vorbis as general build options
-local miniaudioDeps = {
+-- Those dependencies don't have separate [no-]build-* options, instead them use [no-]build-opus-vorbis as general build options
+MINIAUDIO_DEPENDENCIES_METADATA = {
     { name = "opus",     header = "opus/opus.h",          header_subdir = "opus"      },
     { name = "opusfile", header = "opus/opusfile.h",      header_subdir = "opus"      },
     { name = "vorbis",   header = "vorbis/vorbisfile.h"                               },
@@ -92,7 +92,7 @@ local miniaudioDeps = {
 
 -- Default values should be defined at the top of the script instead of the premake options.
 
-for _, dep in ipairs(buildDeps) do
+for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name = dep.name
     local cat  = "YGOPro - " .. name
     newoption { trigger = "build-"    .. name,    category = cat, description = "" }
@@ -101,7 +101,7 @@ for _, dep in ipairs(buildDeps) do
     newoption { trigger = name .. "-lib-dir",     category = cat, description = "", value = "PATH" }
     newoption { trigger = name .. "-lib-name",    category = cat, description = "", value = "NAME" }
 end
-for _, dep in ipairs(miniaudioDeps) do
+for _, dep in ipairs(MINIAUDIO_DEPENDENCIES_METADATA) do
     local name = dep.name
     local cat  = "YGOPro - miniaudio"
     newoption { trigger = name .. "-include-dir", category = cat, description = "", value = "PATH" }
@@ -143,13 +143,16 @@ function FindHeaderWithSubDir(header, subdir)
     return result
 end
 
-function CheckDirectory(varname)
+function EnsureAbsoluteDirectory(varname)
     local dir = _G[varname]
     if not dir or dir == "" then
         print("::warning:: " .. varname .. " is not set")
+        return
     elseif not os.isdir(dir) then
         print("::warning:: " .. varname .. " is not a valid directory: " .. dir)
+        return
     end
+    _G[varname] = path.getabsolute(dir)
 end
 
 -- Get dependency directories from command line or environment variables, and check their validity.
@@ -162,12 +165,12 @@ function GetDependencyDirectory(dep)
     _G[include_dir_var] = GetParam(dep.name .. "-include-dir") or FindHeaderWithSubDir(dep.header, dep.header_subdir)
     _G[lib_name_var] = GetParam(dep.name .. "-lib-name") or _G[lib_name_var] or dep.name
     _G[lib_dir_var] = GetParam(dep.name .. "-lib-dir") or os.findlib(_G[lib_name_var])
-    CheckDirectory(include_dir_var)
-    CheckDirectory(lib_dir_var)
+    EnsureAbsoluteDirectory(include_dir_var)
+    EnsureAbsoluteDirectory(lib_dir_var)
 end
 
 -- Process build flags and external directory settings for all library dependencies.
-for _, dep in ipairs(buildDeps) do
+for _, dep in ipairs(DEPENDENCIES_METADATA) do
     local name  = dep.name
     local upper = string.upper(name)
     local flag  = "BUILD_" .. upper
@@ -210,7 +213,7 @@ if USE_AUDIO then
                 MINIAUDIO_BUILD_OPUS_VORBIS = true
             end
             if not MINIAUDIO_BUILD_OPUS_VORBIS then
-                for _, dep in ipairs(miniaudioDeps) do
+                for _, dep in ipairs(MINIAUDIO_DEPENDENCIES_METADATA) do
                     GetDependencyDirectory(dep)
                 end
             end
@@ -379,35 +382,13 @@ workspace "YGOPro"
 
     include "ocgcore"
     include "gframe"
-    if BUILD_LUA then
-        include "lua"
-    end
-    if BUILD_EVENT then
-        include "event"
-    end
-    if BUILD_FREETYPE then
-        include "freetype"
-    end
-    if BUILD_IRRLICHT then
-        include "irrlicht"
-    end
-    if BUILD_JPEG then
-        include "jpeg"
-    end
-    if BUILD_PNG then
-        include "png"
-    end
-    if BUILD_ZLIB then
-        include "zlib"
-    end
-    if BUILD_SQLITE then
-        include "sqlite"
-    end
-    if BUILD_LZMA then
-        include "lzma/."
+    for _, dep in ipairs(DEPENDENCIES_METADATA) do
+        if _G["BUILD_" .. string.upper(dep.name)] then
+            include(dep.name)
+        end
     end
     if USE_AUDIO then
         if AUDIO_LIB=="miniaudio" then
-            include "miniaudio"
+            include "miniaudio/."
         end
     end

--- a/premake5.lua
+++ b/premake5.lua
@@ -67,7 +67,7 @@ JPEG_INCLUDE_DIR = path.getabsolute("./jpeg/src")
 PNG_INCLUDE_DIR = path.getabsolute("./png")
 ZLIB_INCLUDE_DIR = path.getabsolute("./zlib")
 FREETYPE_INCLUDE_DIR = path.getabsolute("./freetype/include")
-SQLITE_INCLUDE_DIR = path.getabsolute("./sqlite3")
+SQLITE_INCLUDE_DIR = path.getabsolute("./sqlite")
 LZMA_INCLUDE_DIR = path.getabsolute("./lzma/src/liblzma/api")
 
 -- Fields: name, header, header_subdir (for FindHeaderWithSubDir)
@@ -406,7 +406,7 @@ workspace "YGOPro"
         include "zlib"
     end
     if BUILD_SQLITE then
-        include "sqlite3"
+        include "sqlite"
     end
     if BUILD_LZMA then
         include "lzma/."


### PR DESCRIPTION
这项重构的本意是对实际行为只做出有限的改变，但以下行为发生了变更：

sqlite 项目从 "sqlite3" 更名为 "sqlite"
--use-miniaudio 和 --no-use-miniaudio 被移除
修复：原有的*_INCLUDE_DIR的参数在gframe/premake5.lua中消费，而未事先转换为绝对路径。这曾导致用户在命令行参数使用相对路径时，在项目根目录却必须使用相对于gframe中的路径